### PR TITLE
Replacing Cow asset to Pig - Correction

### DIFF
--- a/lib/l10n/app_es_PE.arb
+++ b/lib/l10n/app_es_PE.arb
@@ -13,7 +13,7 @@
   "confirm": "Acceptar",
   "congratulations": "Felicitaciónes",
   "continueButton": "Continuar",
-  "pig": "vaca",
+  "pig": "cerdo",
   "currentCash": "Efectivo disponible: {cashAmount}",
   "dontBuy": "No comprar",
   "enterName": "Por favor, introduzca su nombre y apellido.",


### PR DESCRIPTION
A small correction for the Perú Spanish version - "vaca"  to "cerdo" 